### PR TITLE
[#3] 회원가입 기능 (#4)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,15 +42,15 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation('org.springframework.boot:spring-boot-starter-validation')
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
-        exclude module: 'junit'
+        exclude module: 'junit-platform-commons'
     }
-    testImplementation('org.junit.jupiter:junit-jupiter-api:5.2.0')
-    testCompile('org.junit.jupiter:junit-jupiter-params:5.2.0')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.2.0')
+    testImplementation('org.junit.jupiter:junit-jupiter-api:5.6.2')
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.6.2")
 }
 
 test {

--- a/src/main/java/com/social/instagram/controller/AccountController.java
+++ b/src/main/java/com/social/instagram/controller/AccountController.java
@@ -1,0 +1,40 @@
+package com.social.instagram.controller;
+
+import com.social.instagram.domain.Account;
+import com.social.instagram.dto.AccountDto;
+import com.social.instagram.factory.EncryptionFactory;
+import com.social.instagram.service.AccountService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import javax.validation.Valid;
+import static com.social.instagram.util.httpstatus.ResponseConstants.RESPONSE_ENTITY_CREATE;
+
+
+/*
+    @RestController
+        @Controller + @ResponseBody로 구성되어 있으며 Json 형태로 객체 데이터를 반환합니다.
+    @RequiredArgsConstructor
+        초기화 되지 않은 final 필드, @NonNull 어노테이션이 붙은 필드에 대한 생성자 생성
+    @RequestMapping
+        DefaultAnnotationHandlerMapping에서 컨트롤러를 선택할 때 대표적으로 사용하는 어노테이션
+*/
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/accounts/")
+public class AccountController {
+
+    private final AccountService accountService;
+    private final EncryptionFactory encryptionFactory;
+
+    @PostMapping("sign-up")
+    public ResponseEntity<Void> accountRegister(@Valid @RequestBody AccountDto account) {
+        accountService.accountRegister(Account.changeAccountEntity(account, encryptionFactory.sha256Util()));
+
+        return RESPONSE_ENTITY_CREATE;
+    }
+
+}

--- a/src/main/java/com/social/instagram/domain/Account.java
+++ b/src/main/java/com/social/instagram/domain/Account.java
@@ -1,0 +1,66 @@
+package com.social.instagram.domain;
+
+import com.social.instagram.dto.AccountDto;
+import com.social.instagram.util.encoding.Encryption;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/*
+    @Entity
+    JPA를 사용하여 테이블과 매핑 할 클래스이며 주의해야 할점은 기본생성자 필수이며 final, enum, interface에는 사용불가
+    @NoArgsConstructor
+    기본 생성자를 자동으로 생성
+*/
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Account {
+
+    /*
+        @Id
+        Entity의 primary key를 명시해준다
+        @GeneratedValue
+        기본키의 생성 전략을 결정해준다. 기본값은 Auto이며 IDENTITY의 전략은 기본키 생성을 데이터베이스 위임하는 방법이다.
+    */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String userId;
+
+    private String name;
+
+    private String password;
+
+    private String email;
+
+    private String phone;
+
+    @Builder
+    public Account(String userId, String name, String password, String email, String phone) {
+        this.userId = userId;
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.phone = phone;
+    }
+
+    public static Account changeAccountEntity(AccountDto account, Encryption plainText) {
+
+        return Account.builder()
+                .userId(account.getUserId())
+                .name(account.getName())
+                .password(plainText.changeEncoding(account.getPassword()))
+                .email(account.getEmail())
+                .phone(account.getPhone())
+                .build();
+    }
+
+}

--- a/src/main/java/com/social/instagram/dto/AccountDto.java
+++ b/src/main/java/com/social/instagram/dto/AccountDto.java
@@ -1,0 +1,42 @@
+package com.social.instagram.dto;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+/*
+    @Getter
+    getter 메소드를 자동으로 생성한다.
+*/
+@Getter
+public class AccountDto {
+
+    /*
+            @NotBlank는 null, "", " "를 허용하지 않는다.
+            그렇다면 @NotNull, @NotEmpty와 어떤 차이가 있을까?
+            @NotNull  @NotEmpty  @NotBlank
+        null  허용x       허용x       허용x
+        ""    허용        허용x       허용x
+        " "   허용        허용        허용x
+    */
+    @NotBlank(message = "아이디를 입력해주세요")
+    private String userId;
+
+    @NotBlank(message = "이름을 입력해주세요")
+    private String name;
+
+    @NotBlank(message = "패스워드를 입력해주세요")
+    private String password;
+
+    @NotBlank(message = "이메일을 입력해주세요")
+    private String email;
+
+    /*
+        @Pattern
+        해당 정규식을 만족할 경우에만 통과
+    */
+    @NotBlank(message = "핸드폰번호를 제대로 입력해주세요")
+    @Pattern(regexp = "010-[0-9]{3,4}-[0-9]{4}", message = "010-1234-5678 양식으로 입력해주세요")
+    private String phone;
+}

--- a/src/main/java/com/social/instagram/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/social/instagram/exception/ApiExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.social.instagram.exception;
+
+import com.social.instagram.validation.ErrorMessage;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import static com.social.instagram.util.httpstatus.ResponseConstants.RESPONSE_USER_ID_BAD_REQUEST;
+
+/*
+    @ControllerAdvice
+    컨트롤러에서 발생하는 예외를 잡아서 처리해준다
+*/
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    /*
+        @ExceptionHandler
+        컨트롤러에서 정의한 메소드에서 기술한 예외가 발생하면 자동으로 받아 낼 수 있다.
+    */
+    @ExceptionHandler(DuplicateUserIdException.class)
+    public ResponseEntity<String> handleDuplicateUserIdException() {
+        return RESPONSE_USER_ID_BAD_REQUEST;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException exception) {
+        ErrorMessage errorMessage = new ErrorMessage(exception.getBindingResult().getFieldErrors());
+        return new ResponseEntity<>(errorMessage.getErrorMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/main/java/com/social/instagram/exception/DuplicateUserIdException.java
+++ b/src/main/java/com/social/instagram/exception/DuplicateUserIdException.java
@@ -1,0 +1,6 @@
+
+package com.social.instagram.exception;
+
+public class DuplicateUserIdException extends IllegalArgumentException {
+
+}

--- a/src/main/java/com/social/instagram/factory/EncryptionFactory.java
+++ b/src/main/java/com/social/instagram/factory/EncryptionFactory.java
@@ -1,0 +1,23 @@
+package com.social.instagram.factory;
+
+import com.social.instagram.util.encoding.Sha256Encryption;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/*
+    @Configuration
+    스프링 IOC Container에게 해당 클래스를 Bean구성 Class임을 알려준다
+*/
+@Configuration
+public class EncryptionFactory {
+
+    /*
+        @Bean
+        스프링 컨테이너에 의해 관리되는 객체
+    */
+    @Bean
+    public Sha256Encryption sha256Util() {
+        return new Sha256Encryption();
+    }
+
+}

--- a/src/main/java/com/social/instagram/repository/AccountRepository.java
+++ b/src/main/java/com/social/instagram/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package com.social.instagram.repository;
+
+import com.social.instagram.domain.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+    boolean existsByUserId(String userId);
+}

--- a/src/main/java/com/social/instagram/service/AccountService.java
+++ b/src/main/java/com/social/instagram/service/AccountService.java
@@ -1,0 +1,27 @@
+package com.social.instagram.service;
+
+import com.social.instagram.domain.Account;
+import com.social.instagram.exception.DuplicateUserIdException;
+import com.social.instagram.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+
+    private final AccountRepository accountRepository;
+
+    public void accountRegister(Account account) {
+        checkDuplicateUserId(account.getUserId());
+
+        accountRepository.save(account);
+    }
+
+    public void checkDuplicateUserId(String userId) {
+        if (accountRepository.existsByUserId(userId)) {
+            throw new DuplicateUserIdException();
+        }
+    }
+
+}

--- a/src/main/java/com/social/instagram/util/encoding/Encryption.java
+++ b/src/main/java/com/social/instagram/util/encoding/Encryption.java
@@ -1,0 +1,6 @@
+package com.social.instagram.util.encoding;
+
+public interface Encryption {
+
+    String changeEncoding(String plainText);
+}

--- a/src/main/java/com/social/instagram/util/encoding/EncryptionConstants.java
+++ b/src/main/java/com/social/instagram/util/encoding/EncryptionConstants.java
@@ -1,0 +1,17 @@
+package com.social.instagram.util.encoding;
+
+public class EncryptionConstants {
+
+    public static final int SALT_LENGTH = 10;
+
+    public static final int SHA_256_CONSTANTS = 256;
+
+    public static final int HEXA_DECIMAL = 16;
+
+    public static final int DIGEST_BYTE_EXTRACT = 1;
+
+    public static final String SHA_256_ALGORITHM = "SHA-256";
+
+    public static final String HEXA_TWO_OUTPUT = "%02x";
+
+}

--- a/src/main/java/com/social/instagram/util/encoding/Sha256Encryption.java
+++ b/src/main/java/com/social/instagram/util/encoding/Sha256Encryption.java
@@ -1,0 +1,64 @@
+package com.social.instagram.util.encoding;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Random;
+
+import static com.social.instagram.util.encoding.EncryptionConstants.HEXA_TWO_OUTPUT;
+import static com.social.instagram.util.encoding.EncryptionConstants.SALT_LENGTH;
+import static com.social.instagram.util.encoding.EncryptionConstants.SHA_256_ALGORITHM;
+import static com.social.instagram.util.encoding.EncryptionConstants.SHA_256_CONSTANTS;
+import static com.social.instagram.util.encoding.EncryptionConstants.HEXA_DECIMAL;
+import static com.social.instagram.util.encoding.EncryptionConstants.DIGEST_BYTE_EXTRACT;
+
+public class Sha256Encryption implements Encryption {
+
+    private static String getSalt() {
+        Random random = new Random();
+        byte[] salt = new byte[SALT_LENGTH];
+
+        random.nextBytes(salt);
+
+        StringBuilder saltBuilder = new StringBuilder();
+
+        for (byte saltByte : salt) {
+            saltBuilder.append(String.format(HEXA_TWO_OUTPUT, saltByte));
+        }
+
+        return saltBuilder.toString();
+    }
+
+    private static String getEncrypt(String password, String salt) {
+
+        byte[] saltBytes = salt.getBytes();
+
+        byte[] passwordByte = password.getBytes();
+        byte[] sumPasswordAndSaltBytes = new byte[passwordByte.length + saltBytes.length];
+
+        try {
+            MessageDigest messageDigest = MessageDigest.getInstance(SHA_256_ALGORITHM);
+            messageDigest.update(sumPasswordAndSaltBytes);
+
+            byte[] digest = messageDigest.digest();
+
+            StringBuilder encryptBuilder = new StringBuilder();
+
+            for (byte digestByte : digest) {
+                encryptBuilder.append(Integer.toString((digestByte & 0xFF) + SHA_256_CONSTANTS, HEXA_DECIMAL)
+                        .substring(DIGEST_BYTE_EXTRACT));
+            }
+
+         return encryptBuilder.toString();
+
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("현재 사용할 수 없는 알고리즘 입니다.");
+        }
+
+    }
+
+    @Override
+    public String changeEncoding(String plainText) {
+        return getEncrypt(plainText, getSalt());
+    }
+
+}

--- a/src/main/java/com/social/instagram/util/httpstatus/ResponseConstants.java
+++ b/src/main/java/com/social/instagram/util/httpstatus/ResponseConstants.java
@@ -1,0 +1,14 @@
+package com.social.instagram.util.httpstatus;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ResponseConstants {
+
+    public static final ResponseEntity<Void> RESPONSE_ENTITY_CREATE =
+            ResponseEntity.status(HttpStatus.CREATED).build();
+
+    public static final ResponseEntity<String> RESPONSE_USER_ID_BAD_REQUEST =
+            ResponseEntity.badRequest().body("중복된 userId 입니다");
+
+}

--- a/src/main/java/com/social/instagram/validation/ErrorMessage.java
+++ b/src/main/java/com/social/instagram/validation/ErrorMessage.java
@@ -1,0 +1,41 @@
+package com.social.instagram.validation;
+
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+/*
+    ErrorMessage 사용 이유
+
+    1. 불변 객체를 만들기 위한 목적
+    @Valid 유효성에 대한 에러메시지 만드는데 List<FieldError> 타입을 이용하여 데이터를 처리하고 반환 해준다.
+    하지만 이때 List<FieldError>의 메소드에 대한 조작이 가능한데 이 말은 데이터를 조작할 수 있다는 말이다. 소프트웨어 규모가 커지고 있는 상황에서
+    불변 객체는 아주 중요하다. 각각의 객체들이 절대 값이 바뀔 일이 없다는게 보장되면 그 만큼 코드를 이해하고 수정하는데 side-effect가 최소화 되기
+    때문에 불변으로 만들었다.
+
+    2. 의도하고자 하는 naming 사용하기 위한 목적
+    List<FieldError>의 변수를 사용하는 것보다 의도가 담긴 클래스 naming을 사용한다면 목적을 쉽게 파악 할 수 있다.
+    List<FieldError>의 변수 하나만 사용한다면 장점을 크게 못느끼겠지만 다른 DTO 유효성에 대한 에러를 처리하기 위해 변수가 생겨난다면 그때서야 장점을
+    느낄 것이다.
+
+*/
+public class ErrorMessage {
+
+    private final List<FieldError> errorMessage;
+    private static final String LINE_BREAK = "\n";
+
+    public ErrorMessage(List<FieldError> errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        StringBuilder errorResult = new StringBuilder();
+
+        for (FieldError fieldError : errorMessage) {
+            errorResult.append(fieldError.getDefaultMessage()).append(LINE_BREAK);
+        }
+
+        return errorResult.toString();
+    }
+
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,25 @@
+spring:
+
+  #데이터베이스 연결해주는 설정
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/instagram?serverTimezone=UTC&characterEncoding=UTF-8
+    username: root
+    password: password
+
+  jpa:
+    properties:
+      hibernate:
+        #hibernate가 DB에 날리는 모든 쿼리 출력
+        show_sql: true
+        #보여지는 쿼리를 이쁘게 출력
+        format_sql: true
+
+#hibernate가 ?에 어떤값이 들어가 있는지 구체적으로 알려주는 설정
+logging:
+  level:
+    org:
+      hibernate:
+        type:
+          descriptor:
+            sql: trace

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+# 로컬/운영 환경설정을 분리하는 작업
+spring:
+  profiles:
+    active: local
+
+---

--- a/src/test/java/com/social/instagram/service/AccountServiceTest.java
+++ b/src/test/java/com/social/instagram/service/AccountServiceTest.java
@@ -1,0 +1,62 @@
+package com.social.instagram.service;
+
+import com.social.instagram.domain.Account;
+import com.social.instagram.exception.DuplicateUserIdException;
+import com.social.instagram.repository.AccountRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountServiceTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @InjectMocks
+    private AccountService accountService;
+
+    private Account account;
+
+    @BeforeEach
+    public void setUp() {
+        this.account = createAccount();
+    }
+
+    @Test
+    @DisplayName("회원가입을 성공적으로 수행한다")
+    public void account_register_success() {
+        accountService.accountRegister(account);
+
+        verify(accountRepository).save(account);
+    }
+
+    @Test
+    @DisplayName("회원가입 할 때 중복된 아이디가 있으면 실패한다.")
+    public void account_register_duplicate_userId_fail() {
+        when(accountRepository.existsByUserId("test")).thenReturn(true);
+
+        assertThrows(DuplicateUserIdException.class,
+                () -> accountService.checkDuplicateUserId("test"));
+
+        verify(accountRepository).existsByUserId("test");
+    }
+
+    private Account createAccount() {
+        return Account.builder()
+                .userId("abc@naver.com")
+                .name("test")
+                .password("qweoajasdkjansd1298")
+                .email("abc@hanmail.net")
+                .phone("010-1234-5678")
+                .build();
+    }
+
+}


### PR DESCRIPTION
* [#3] 회원가입 기능

- 회원가입 구현, 테스트 코드 작성
- 추후에 Global Exception Handling 검토

* 회원가입 리뷰 반영

- AccountController의 accountRegister api 이름 변경
- ResponseEntity 리턴 값 상수 적용
- NoArgsConstructor(AccessLevel.PROTECTED) 적용
- application.yml 로컬/운영 환경설정 분리
- 암호화 확장

* 회원가입 리뷰 반영

- ResponseEntity 리턴 값 명확한 이름으로 변경
- ResponseEntity error, success 분리(유지보수성)
- Exception Handling 적용
- EncryptionFactory bean 등록
- 추후에 sha256Util, sha256Service naming 결정

* 회원가입 리뷰 반영

- CheckStyle 적용
- ResponseConstants naming 변경

* 회원가입 리뷰 반영

- ResponseConstants로 naming 변경

* 회원가입 기능

- AccountDto message 수정
- MethodArgumentNotValidException handler 추가
- ErrorMessage 생성

* 회원가입 기능

- ErrorMessage 가독성 증가 및 부연 설명

* 회원가입 기능

- ErrorMessage 줄바꿈 문자 상수 적용

* 회원가입 기능

- EncryptionEncoding, Sha256Encoding으로 naming 변경
- Encoding에 관한 상수 분리
- ErrorMessage 주석 수정

* 회원가입 리뷰 반영

- 암호화 naming Encryption으로 변경